### PR TITLE
Remove plugin-offline-sync-client dist folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ pnpm-lock.yaml
 pnpm-debug.log
 **/broadcast/**
 wip/
+packages/plugin-offline-sync-client/dist

--- a/packages/plugin-offline-sync-client/dist/index.d.ts
+++ b/packages/plugin-offline-sync-client/dist/index.d.ts
@@ -1,4 +1,0 @@
-export { default as OfflineSyncClientPlugin, default } from './plugin.js';
-import '@cinderlink/core-types';
-import 'emittery';
-import '@cinderlink/plugin-offline-sync-core';


### PR DESCRIPTION
## Summary
- delete `packages/plugin-offline-sync-client/dist`
- add the path to `.gitignore`

## Testing
- `npm test` *(fails: vitest cannot resolve package)*